### PR TITLE
Getting array from slice of cube causes shape error

### DIFF
--- a/ds9.py
+++ b/ds9.py
@@ -518,7 +518,7 @@ class ds9(object):
                 arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((d,h,w))
             else:
                 arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((h,w))
-            if sys.byteorder != 'big': arr.byteswap(True)
+            #if sys.byteorder != 'big': arr.byteswap(True)
             return arr
 
         def set_np2arr(self, arr, dtype=None):


### PR DESCRIPTION
If I try to `get_arr2np` from a slice of a data cube, I run into a shape error.  I'll examine further to see if I can come up with a fix.

```
In [58]: D = ds9.ds9(target='86ab230f:53612', start=False)

In [59]: D.get("file")
Out[59]: '/Users/adam/work/h2co/apex/H2CO_322221_to_303202_cube_temperature_masked_proj_to_ammonia.fits[plane=31]'

In [60]: arr1 = D.get_arr2np()
Traceback (most recent call last):
  File "<ipython-input-60-76c9d7f2d441>", line 1, in <module>
    arr1 = D.get_arr2np()
  File "/Users/adam/virtual-python/lib/python2.7/site-packages/ds9.py", line 516, in get_arr2np
    arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((w,h))
ValueError: total size of new array must be unchanged

> /Users/adam/virtual-python/lib/python2.7/site-packages/ds9.py(516)get_arr2np()
    515             s = self.get('array')
--> 516             arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((w,h))
    517             if sys.byteorder != 'big': arr.byteswap(True)

ipdb> print w,h,len(s)
961 241 105610056
ipdb> print w*h
231601
```
