### PR TITLE
added backwards-compat ds9 module

### DIFF
--- a/ds9.py
+++ b/ds9.py
@@ -1,0 +1,7 @@
+from pyds9 import *
+from warnings import warn as _warn
+
+_warn('You are importing pyds9 via the `ds9` package.  This package is now  '
+      'deprecated in favor of `pyds9`.  In the future you should usd '
+      '``import pyds9`` instead of ``import ds9``.  ``ds9`` will continue to '
+      'work, but may be removed in the future.')

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(name='pyds9',
     author='Bill Joye and Eric Mandel',
     author_email='saord@cfa.harvard.edu',
     url='http://hea-www.harvard.edu/saord/ds9/',
-    py_modules=['pyds9', 'xpa'],
+    py_modules=['pyds9', 'xpa', 'ds9'],
     data_files=[('', [xpadir+'/'+xpalib, xpadir+'/'+xpans])],
     cmdclass = {'build_py': my_build_py, 	 \
                 'install_data': my_install_data, \


### PR DESCRIPTION
Following on from #6, I realized that there is now another compatibility issue: users who do `import ds9` will have now have their code not work because it's all been moved to `pyds9`.  This PR adds a comatibility layer such that `import ds9` will still work, but displays a warning that the should switch to `pyds9` and `ds9` may not work in the future.

cc @ericmandel
