### PR TITLE
Explicitly use system endianness for "=" dtype

### DIFF
--- a/pyds9.py
+++ b/pyds9.py
@@ -590,8 +590,10 @@ class DS9(object):
 
             # note that this needs the "endian=" part because sometimes it's
             # left out completely
-            endianness = ''  # mainly this is for the "=" byteorder->native
-            if narr.dtype.byteorder == '<':
+            endianness = ''
+            if narr.dtype.byteorder == '=':
+                endianness = ',endian=' + sys.byteorder
+            elif narr.dtype.byteorder == '<':
                 endianness = ',endian=little'
             elif narr.dtype.byteorder == '>':
                 endianness = ',endian=big'


### PR DESCRIPTION
This is a follow-on to #10 that I just realized seems to be necessary.

For some reason, at least on my system right now, if you don't specify the endianness, ds9 sometimes just picks one that is *not* the system endianness.  It seems to depend on the bitpix value somehow, but I can't really tell exactly what it's doing.  So for safety's sake, this just forces the endianess for an array of dtype ``'='`` to just be whatever the system endianness is.

I *thought* this is exactly what ds9 does, but it isn't always working for me, so this seems to be more reliable.