### PR TITLE
Dynamically discover path to XPA; favoring the host over the built-in

### DIFF
--- a/pyds9/xpa.py
+++ b/pyds9/xpa.py
@@ -12,13 +12,28 @@ import ctypes.util
 
 # look for the shared library in sys.path
 def _find_shlib(_libbase):
+    # Search relative to the interpreter, then relative to the xpa module
+    dirs_ = [
+        os.path.join(sys.prefix, 'lib'),
+        os.path.join(sys.prefix, 'lib64'),
+        os.path.dirname(__file__)
+    ]
+    pattern = 'lib' + _libbase + '*'
+    libxpa = []
 
-    dir_ = os.path.dirname(__file__)
-    libxpa = glob.glob(os.path.join(dir_, "libxpa*so*"))
+    for d in dirs_:
+        libxpa.append(glob.glob(os.path.join(d, pattern)))
+
     if libxpa:
-        return libxpa[0]
-    else:
-        return None
+        # Flatten search results, and return first match
+        # (Ignores static archives)
+        libxpa = [x for y in libxpa
+                  for x in y if not x.endswith('.a')
+                  or not x.endswith('.lib')]
+        if libxpa:
+            return libxpa[0]
+
+    return None
 
 _libpath = _find_shlib('xpa')
 if _libpath:


### PR DESCRIPTION
In the interest of using a pre-existing XPA library this PR searches relative to `sys.prefix` first, and if no `libxpa.(so|dylib|dll)` is found, it falls back on the built-in version provided by `pyds9`.

I added in `lib64` for CentOS systems, but search `lib` first because it's likely to be the "correct" hit. In Anaconda, for example, `sys.prefix` resolves to `/path/to/anaconda/[env]/lib`, but a system-installation of XPA on a 64-bit system could place `libxpa` in `lib64`. This also works well with normal virtualenv paths that have XPA installed directly into it.
