### PR TITLE
astropy and numpy are now dependences, pyfits can be used.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -84,6 +84,9 @@ matrix:
         - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='numpy ds9'
                SETUP_CMD='egg_info'
 
+        # Try with pyfits
+        - env: PIP_DEPENDENCIES='pytest-xvfb pyfits'
+
         # Try with sphinx
         # - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='sphinx'
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ matrix:
 
         # Try Astropy development and lts version
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=development
-               PIP_DEPENDENCIES='pytest-astropy'
+               PIP_DEPENDENCIES='pytest-astropy pytest-xvfb'
         - env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts NUMPY_VERSION=1.12
                CONDA_CHANNELS='astropy-ci-extras'
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -116,7 +116,7 @@ before_script:
     # on MacOSX try to start Xvfb
     # Taken from https://github.com/travis-ci/travis-ci/issues/7313 and
     # https://github.com/widelands/widelands/commit/68b2bbe95c91f5305924154af9c36c63cdc773a0
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; export DISPLAY=:99.0; ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& ; sleep 3; fi
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DISPLAY=:99.0; ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& sleep 3; fi
 
 script:
    - ${MAIN_CMD} $SETUP_CMD

--- a/.travis.yml
+++ b/.travis.yml
@@ -112,6 +112,12 @@ install:
     # section if they are needed before setting up conda) to install any
     # other dependencies.
 
+before_script:
+    # on MacOSX try to start Xvfb
+    # Taken from https://github.com/travis-ci/travis-ci/issues/7313 and
+    # https://github.com/widelands/widelands/commit/68b2bbe95c91f5305924154af9c36c63cdc773a0
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; export DISPLAY=:99.0; ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& ; sleep 3; fi
+
 script:
    - ${MAIN_CMD} $SETUP_CMD
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,6 +74,7 @@ matrix:
 
         # Try Astropy development and lts version
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=development
+               PIP_DEPENDENCIES='pytest-astropy'
         - env: PYTHON_VERSION=2.7 ASTROPY_VERSION=lts NUMPY_VERSION=1.12
                CONDA_CHANNELS='astropy-ci-extras'
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=lts NUMPY_VERSION=1.12

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
         - ASTROPY_VERSION=stable
         - MAIN_CMD='python setup.py'
         - SETUP_CMD='test'
-        - PIP_DEPENDENCIES=''
+        - PIP_DEPENDENCIES='pytest-xvfb'
 
         # For this package-template, we include examples of Cython modules,
         # so Cython is required for testing. If your package does not include

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -12,6 +12,7 @@ recursive-include licenses *
 recursive-include cextern *
 recursive-include cextern/xpa *
 recursive-include scripts *
+recursive-include pyds9/tests/data *
 
 prune build
 prune docs/_build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,6 +14,7 @@ environment:
       # so Cython is required for testing. If your package does not include
       # Cython code, you can set CONDA_DEPENDENCIES=''
       CONDA_DEPENDENCIES: "Cython"
+      PIP_DEPENDENCIES: "pytest-xvfb"
 
   matrix:
 

--- a/pyds9/conftest.py
+++ b/pyds9/conftest.py
@@ -4,14 +4,17 @@
 
 from astropy.tests.pytest_plugins import *
 
-## Uncomment the following line to treat all DeprecationWarnings as
-## exceptions
-# enable_deprecations_as_exceptions()
+import py.path
+import pytest
 
-## Uncomment and customize the following lines to add/remove entries from
-## the list of packages for which version numbers are displayed when running
-## the tests. Making it pass for KeyError is essential in some cases when
-## the package uses other astropy affiliated packages.
+# Uncomment the following line to treat all DeprecationWarnings as
+# exceptions
+# pytest_plugins.enable_deprecations_as_exceptions()
+
+# Uncomment and customize the following lines to add/remove entries from
+# the list of packages for which version numbers are displayed when running
+# the tests. Making it pass for KeyError is essential in some cases when
+# the package uses other astropy affiliated packages.
 # try:
 #     PYTEST_HEADER_MODULES['Astropy'] = 'astropy'
 #     PYTEST_HEADER_MODULES['scikit-image'] = 'skimage'
@@ -36,3 +39,16 @@ try:
     TESTED_VERSIONS[packagename] = version
 except NameError:   # Needed to support Astropy <= 1.0.0
     pass
+
+
+@pytest.fixture
+def test_data_dir():
+    '''Returns the name of the test data directory as a py.path.local object'''
+    this_file = py.path.local(__file__)
+    return this_file.dirpath('tests', 'data')
+
+
+@pytest.fixture
+def test_fits(test_data_dir):
+    '''Returns the name of the test fits file as a py.path.local object'''
+    return test_data_dir.join('test.fits')

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -754,7 +754,7 @@ class DS9(object):
             #                      " 'get_pyfits'. The method is available"
             #                      " only"
             #                      " if the package 'pyfits' is imported and"
-            #                      " it's version >=2.2")
+            #                      " its version is >=2.2")
         return pyfits.open(self._ds9_fits_to_bytes())
 
     def set_pyfits(self, hdul):
@@ -798,7 +798,7 @@ class DS9(object):
             #                      " 'set_pyfits'. The method is available
             #                      " only"
             #                      " if the package 'pyfits' is imported and"
-            #                      " it's version >=2.2")
+            #                      " its version is >=2.2")
         if not isinstance(hdul, pyfits.HDUList):
             raise ValueError('The input must be a pyfits HDUList')
         return self._hdulist_to_ds9_fits(hdul)

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -741,10 +741,20 @@ class DS9(object):
             if pyfits is not available on the system
         """
         if not ds9Globals["pyfits"]:
-            raise AttributeError("'DS9' object has not attribute"
-                                 " 'get_pyfits'. The method is available only"
-                                 " if the package 'pyfits' is imported and"
-                                 " it's version >=2.2")
+            warnings.warn('"get_pyfits" method should be used only to'
+                          ' retrieve from ds9 fits as "pyfits" HDUList.'
+                          ' Modify your code to use ``get_fits`` to get'
+                          ' "astropy" HDUList or, if you really want to use'
+                          ' "pyfits", install it. In the future this warning'
+                          ' will turn into an exception')
+            return self.get_fits()
+            # TODO: remove the above warning and make this method available
+            # only if pyfits is installed
+            # raise AttributeError("'DS9' object has not attribute"
+            #                      " 'get_pyfits'. The method is available"
+            #                      " only"
+            #                      " if the package 'pyfits' is imported and"
+            #                      " it's version >=2.2")
         return pyfits.open(self._ds9_fits_to_bytes())
 
     def set_pyfits(self, hdul):
@@ -775,10 +785,20 @@ class DS9(object):
             if the input is not a pyfits HDUList
         """
         if not ds9Globals["pyfits"]:
-            raise AttributeError("'DS9' object has not attribute"
-                                 " 'set_pyfits'. The method is available only"
-                                 " if the package 'pyfits' is imported and"
-                                 " it's version >=2.2")
+            warnings.warn('"set_pyfits" method should be used only to'
+                          ' send to ds9 fits as "pyfits" HDUList.'
+                          ' Modify your code to use ``set_fits`` to set'
+                          ' "astropy" HDUList or, if you really want to use'
+                          ' "pyfits", install it. In the future this warning'
+                          ' will turn into an exception')
+            return self.set_fits(hdul)
+            # TODO: remove the above warning and make this method available
+            # only if pyfits is installed
+            # raise AttributeError("'DS9' object has not attribute"
+            #                      " 'set_pyfits'. The method is available
+            #                      " only"
+            #                      " if the package 'pyfits' is imported and"
+            #                      " it's version >=2.2")
         if not isinstance(hdul, pyfits.HDUList):
             raise ValueError('The input must be a pyfits HDUList')
         return self._hdulist_to_ds9_fits(hdul)

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -178,7 +178,6 @@ def _np2bp(dtype):
     int
         FITS bitpix type
 
-
     Raises
     ------
     ValueError
@@ -766,8 +765,8 @@ class DS9(object):
         dtype: data type, optional
             convert array to ``dtype`` before sending
 
-        Parameters
-        ----------
+        Returns
+        -------
         int :
             1 for success, 0 for failure
 

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -383,12 +383,12 @@ class DS9(object):
     In addition, a number of special methods are implemented to facilitate data
     access to/from python objects:
 
-    - get_arr2np: retrieve a FITS image or an array into a numpy array
-    - set_np2arr: send a numpy array to ds9 for display
-    - get_fits: retrieve a FITS image into an astropy  hdu list
-    - set_fits: send an astropy hdu list to ds9 for display
-    - get_pyfits: retrieve a FITS image into a pyfits hdu list
-    - set_pyfits: send a pyfits hdu list to ds9 for display
+    - :meth:`get_arr2np`: retrieve a FITS image or an array into a numpy array
+    - :meth:`set_np2arr`: send a numpy array to ds9 for display
+    - :meth:`get_fits`: retrieve a FITS image into an astropy  hdu list
+    - :meth:`set_fits`: send an astropy hdu list to ds9 for display
+    - :meth:`get_pyfits`: retrieve a FITS image into a pyfits hdu list
+    - :meth:`set_pyfits`: send a pyfits hdu list to ds9 for display
     """
 
     # access points that do not get trailing cr stripped from them
@@ -633,8 +633,8 @@ class DS9(object):
     def get_fits(self):
         """Retrieve data from ds9 as an astropy FITS.
 
-        Example
-        -------
+        Examples
+        --------
 
         >>> hdul = d.get_fits()
         >>> hdul.info()
@@ -647,7 +647,7 @@ class DS9(object):
 
         Returns
         -------
-        :class:`astropy.io.fits.hdu.hdulist.HDUList`
+        :class:`astropy.io.fits.HDUList`
             FITS object
         """
         self._selftest()
@@ -658,15 +658,15 @@ class DS9(object):
     def set_fits(self, hdul):
         """Display an astropy FITS in ds9.
 
-        Example
-        -------
+        Examples
+        --------
 
         >>> d.set_pyfits(nhdul)
         1
 
         Parameters
         ----------
-        :class:`astropy.io.fits.hdu.hdulist.HDUList`
+        hdul : :class:`astropy.io.fits.HDUList`
             FITS object to display
 
         Returns
@@ -681,7 +681,7 @@ class DS9(object):
             if the input is not an astropy HDUList
         """
         self._selftest()
-        if isinstance(hdul, fits.HDUList):
+        if not isinstance(hdul, fits.HDUList):
             raise ValueError('The input must be an astropy HDUList')
         # for python2 BytesIO and StringIO are the same
         with contextlib.closing(BytesIO()) as newFitsFile:

--- a/pyds9/tests/setup_package.py
+++ b/pyds9/tests/setup_package.py
@@ -1,3 +1,7 @@
+import os
+
+
 def get_package_data():
     return {
-        _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc']}
+        _ASTROPY_PACKAGE_NAME_ + '.tests': ['coveragerc'],
+        'pyds9.tests': [os.path.join('data', '*')]}

--- a/pyds9/tests/test_fits.py
+++ b/pyds9/tests/test_fits.py
@@ -1,6 +1,0 @@
-from pyds9 import pyds9
-
-
-def test_fits():
-    """Add your tests"""
-    assert True

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -59,6 +59,32 @@ def test_np2bp(dtype, bitpix):
     assert output == bitpix
 
 
-def test_ds9(ds9_title):
-    ''''''
-    ds9 = pyds9.ds9_openlist(target=ds9_title)[0]
+def test_ds9_targets_empty():
+    '''If no ds9 instance is running, ds9_targets returns None'''
+    targets = pyds9.ds9_targets()
+    assert targets is None
+
+
+def test_ds9_targets(ds9_title):
+    '''ds9_targets returns open ds9 names'''
+    targets = pyds9.ds9_targets()
+    assert len(targets) == 1
+    assert ds9_title in targets[0]
+
+
+@pytest.mark.xfail(raises=ValueError, reason='No target ds9 instance')
+def test_ds9_openlist_empty():
+    '''If no ds9 instance is running, ds9_openlist raises an exception'''
+    pyds9.ds9_openlist()
+
+
+def test_ds9_openlist(ds9_title):
+    '''ds9_openlist returns running ds9 instances'''
+    ds9s = pyds9.ds9_openlist()
+    assert len(ds9s) == 1
+    assert ds9_title in ds9s[0].target
+
+
+# def test_ds9(ds9_title):
+    # ''''''
+    # ds9 = pyds9.ds9_openlist(target=ds9_title)[0]

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -1,3 +1,7 @@
+import random
+import subprocess as sp
+import time
+
 import numpy as np
 import pytest
 
@@ -19,6 +23,26 @@ type_mapping = parametrize('bitpix, dtype ',
                             ])
 
 
+@pytest.fixture
+def ds9_title():
+    '''Start a ds9 instance in a subprocess and returns its title'''
+    name = 'test.{}'.format(random.randint(0, 10000))
+    cmd = ['ds9', '-title', name]
+    p = sp.Popen(cmd)
+    # wait for ds9 to come alive
+    while not pyds9.ds9_targets():
+        time.sleep(0.1)
+
+    yield name
+
+    returncode = p.poll()
+    if returncode is None:
+        p.kill()
+        p.communicate()
+    elif returncode != 0:
+        raise sp.CalledProcessError(returncode, ' '.join(cmd))
+
+
 @type_mapping
 def test_bp2np(dtype, bitpix):
     """Test from bitpix to dtype"""
@@ -33,3 +57,8 @@ def test_np2bp(dtype, bitpix):
     output = pyds9._np2bp(dtype)
 
     assert output == bitpix
+
+
+def test_ds9(ds9_title):
+    ''''''
+    ds9 = pyds9.ds9_openlist(target=ds9_title)[0]

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -1,0 +1,35 @@
+import numpy as np
+import pytest
+
+from pyds9 import pyds9
+
+parametrize = pytest.mark.parametrize
+
+type_mapping = parametrize('bitpix, dtype ',
+                           [(8, np.dtype(np.uint8)),
+                            (16, np.dtype(np.int16)),
+                            (32, np.dtype(np.int32)),
+                            (64, np.dtype(np.int64)),
+                            (-32, np.dtype(np.float32)),
+                            (-64, np.dtype(np.float64)),
+                            (-16, np.dtype(np.uint16)),
+                            pytest.mark.xfail(raises=ValueError,
+                                              reason='Wrong input')
+                                             ((42, np.dtype(str)))
+                            ])
+
+
+@type_mapping
+def test_bp2np(dtype, bitpix):
+    """Test from bitpix to dtype"""
+    output = pyds9._bp2np(bitpix)
+
+    assert output == dtype
+
+
+@type_mapping
+def test_np2bp(dtype, bitpix):
+    """Test from dtype to bitpix"""
+    output = pyds9._np2bp(dtype)
+
+    assert output == bitpix

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,8 +8,8 @@ upload-dir = docs/_build/html
 show-response = 1
 
 [tool:pytest]
-minversion = 2.2
-norecursedirs = build docs/_build
+minversion = 3.0
+norecursedirs = build docs/_build pyds9/data
 doctest_plus = enabled
 
 [ah_bootstrap]


### PR DESCRIPTION
- [x] numpy is a dependancy, there is no need to check it
- [x] astropy is a dependancy, there is no need to check it
- [x] make it possible to use either astropy or pyfits fits representation. Will help for cases like #51 