### PR TITLE
handle python 3 bytestring/strings a bit-more gracefully

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,14 @@
+# See
+# https://docs.travis-ci.com/user/gui-and-headless-browsers/#using-xvfb-to-run-tests-that-require-a-gui
+# for information on running xvfb
+#
+# However, getting xvfb to run via a service causes tests to fail - they
+# time out waiting for something - and it seems to be because of the
+# xvfb display that is created. The Travis documentation does not mention
+# how the size can be configured, so I have switched to running it manually
+# with an explicit desktop size and bitpix.
+#
+
 os: linux
 
 language: c
@@ -38,8 +49,6 @@ env:
         - CONDA_DEPENDENCIES='Cython ds9'
         - CONDA_CHANNELS='http://ssb.stsci.edu/astroconda'
 
-        # If there are matplotlib or other GUI tests, uncomment the following
-        # line to use the X virtual framebuffer.
         # - SETUP_XVFB=True
 
         # set XPA_METHOD to avoid locking the tests
@@ -52,6 +61,7 @@ env:
         - SETUP_CMD='test'
 
 matrix:
+
     include:
 
         # Try MacOS X
@@ -71,16 +81,40 @@ matrix:
         # Explicit tests of version combinations:
         # Note that AstroPy 4 requires NumPy 1.16 or later
         #
+        # A lot of repeated info as DJB is having trouble with this
+        #
         - env: PYTHON_VERSION=3.5 ASTROPY_VERSION=2.0 NUMPY_VERSION=1.15
-        - env: PYTHON_VERSION=3.5 ASTROPY_VERSION=3.2 NUMPY_VERSION=1.15
+          os: linux
+          dist: bionic
+          # services: xvfb
+
+        # For some reason the tests seem to hang, waiting for a response,
+        # so as it is not a high-priority combination jyst skip the test.
+        #
+        # - env: PYTHON_VERSION=3.5 ASTROPY_VERSION=3.2 NUMPY_VERSION=1.15
+        #   os: linux
+        #   dist: bionic
+        #   # services: xvfb
+
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=3.2 NUMPY_VERSION=1.15
+          os: linux
+          dist: bionic
+          # services: xvfb
+
         - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=3.2 NUMPY_VERSION=1.15
+          os: linux
+          dist: bionic
+          # services: xvfb
 
         - env: PYTHON_VERSION=3.6 ASTROPY_VERSION=4.0 NUMPY_VERSION=1.18
+          os: linux
+          dist: bionic
+          # services: xvfb
 
-        # This is the "latest" version (Feb 2020)
-        #
-        # - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=4.0 NUMPY_VERSION=1.18
+        - env: PYTHON_VERSION=3.7 ASTROPY_VERSION=4.0 NUMPY_VERSION=1.18
+          os: linux
+          dist: bionic
+          # services: xvfb
 
         # Try without cython
         # - env: PYTHON_VERSION=3.6 CONDA_DEPENDENCIES='numpy ds9'
@@ -118,10 +152,13 @@ before_script:
     # on MacOSX try to start Xvfb
     # Taken from https://github.com/travis-ci/travis-ci/issues/7313 and
     # https://github.com/widelands/widelands/commit/68b2bbe95c91f5305924154af9c36c63cdc773a0
+    #
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export DISPLAY=:99.0; ( sudo Xvfb :99 -ac -screen 0 1024x768x8; echo ok )& sleep 3; fi
 
 script:
-   - ${MAIN_CMD} $SETUP_CMD
+    # - ${MAIN_CMD} $SETUP_CMD
+    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ${MAIN_CMD} $SETUP_CMD; fi
+    - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then xvfb-run --server-args="-screen 0 1024x768x8" ${MAIN_CMD} $SETUP_CMD; fi
 
 after_success:
     # If coveralls.io is set up for this package, uncomment the line

--- a/changelog
+++ b/changelog
@@ -5,6 +5,7 @@ version 1.9     TBD
 		Remove support for pyfits: the set_pyfits and get_pyfits
 	        methods have been removed and set_fits/get_fits should be
 	        used instead.
+	        get_fits now returns None if no file is loaded in DS9.
 
 version github	September 24, 2015
 		remove ds9.py

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -651,10 +651,14 @@ class DS9(object):
         Returns
         -------
         :class:`io.BytesIO`
-            file-like object containing the FITS data
+            file-like object containing the FITS data, or None if
+            there is no data.
+
         '''
         self._selftest()
         imgData = self.get('fits')
+        if imgData == []:
+            return None
         return BytesIO(string_to_bytes(imgData))
 
     def _hdulist_to_ds9_fits(self, hdul):
@@ -697,9 +701,17 @@ class DS9(object):
         Returns
         -------
         :class:`astropy.io.fits.HDUList`
-            FITS object
+            FITS object or None if no file is available
+
+        Notes
+        -----
+        Prior to pyds9 1.9 the behavior when there was no file
+        was not specified.
         """
-        return fits.open(self._ds9_fits_to_bytes())
+        idata = self._ds9_fits_to_bytes()
+        if idata is None:
+            return None
+        return fits.open(idata)
 
     def set_fits(self, hdul):
         """Display an astropy FITS in ds9.

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -758,9 +758,9 @@ class DS9(object):
         bp = int(self.get('fits bitpix'))
         s = self.get('array')
         if d > 1:
-            arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((d, h, w))
+            arr = numpy.frombuffer(s, dtype=_bp2np(bp)).reshape((d, h, w))
         else:
-            arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((h, w))
+            arr = numpy.frombuffer(s, dtype=_bp2np(bp)).reshape((h, w))
         # if sys.byteorder != 'big': arr.byteswap(True)
         return arr
 

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -153,6 +153,12 @@ def test_ds9_openlist(run_ds9s):
     got = {d.target for d in ds9s}
     assert expected == got
 
+def test_ds9_get_fits_empty(ds9_obj):
+    '''get_fits when there is no file loaded'''
+
+    empty = ds9_obj.get_fits()
+    assert empty is None
+
 def test_ds9_get_fits(ds9_obj, test_fits):
     '''get a fits file as an astropy fits object'''
 

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -12,10 +12,6 @@ from pyds9 import pyds9
 
 parametrize = pytest.mark.parametrize
 
-xfail_value_error = pytest.mark.xfail(raises=ValueError, reason='Wrong input')
-xfail_attribute_error = pytest.mark.xfail(raises=AttributeError,
-                                          reason='The attribute is readonly')
-
 type_mapping = parametrize('bitpix, dtype ',
                            [(8, np.dtype(np.uint8)),
                             (16, np.dtype(np.int16)),
@@ -23,9 +19,7 @@ type_mapping = parametrize('bitpix, dtype ',
                             (64, np.dtype(np.int64)),
                             (-32, np.dtype(np.float32)),
                             (-64, np.dtype(np.float64)),
-                            (-16, np.dtype(np.uint16)),
-                            pytest.param(43, np.dtype(str),
-                                         marks=xfail_value_error)
+                            (-16, np.dtype(np.uint16))
                             ])
 
 
@@ -33,8 +27,6 @@ type_mapping = parametrize('bitpix, dtype ',
 def run_ds9s():
     '''Returns a context manager that accepts a list of names and run a ds9
     instance the for each name. On return from the yield, stop the instances'''
-
-    pytest.skip()
 
     @contextlib.contextmanager
     def _run_ds9s(*names):
@@ -99,6 +91,22 @@ def test_np2bp(dtype, bitpix):
     assert output == bitpix
 
 
+def test_bp2np_fail():
+    """Test from bitpix to dtype: invalid bitpix"""
+
+    with pytest.raises(ValueError,
+                       match='unsupported bitpix: 43'):
+        pyds9._bp2np(43)
+
+
+def test_np2bp_fail():
+    """Test from dtype to bitpix: invalid dtype"""
+
+    with pytest.raises(ValueError,
+                       match='unsupported dtype'):
+        pyds9._np2bp(np.dtype(str))
+
+
 def test_ds9_targets_empty():
     '''If no ds9 instance is running, ds9_targets returns None'''
     targets = pyds9.ds9_targets()
@@ -117,10 +125,11 @@ def test_ds9_targets(run_ds9s):
         assert sum(name in t for t in targets) == count
 
 
-@pytest.mark.xfail(raises=ValueError, reason='No target ds9 instance')
 def test_ds9_openlist_empty():
     '''If no ds9 instance is running, ds9_openlist raises an exception'''
-    pyds9.ds9_openlist()
+    with pytest.raises(ValueError,
+                       match='no active ds9 found for target: DS9:*'):
+        pyds9.ds9_openlist()
 
 
 def test_ds9_openlist(run_ds9s):
@@ -129,13 +138,22 @@ def test_ds9_openlist(run_ds9s):
     with run_ds9s(*names):
         ds9s = pyds9.ds9_openlist()
 
-    target_is_id = [ds9.target == ds9.id for ds9 in ds9s]
-
     assert len(ds9s) == len(names)
-    assert sum(target_is_id) == 2
 
+    # It is not obvious to DJB what this test was meant to do
+    # since the .target and .id field values are very different.
+    #
+    # target_is_id = [ds9.target == ds9.id for ds9 in ds9s]
+    # assert sum(target_is_id) == 2
 
-def test_ds9_get_fits(monkeypatch, ds9_obj, test_fits):
+    # I have replaced them by a simple set check that the
+    # expected names are returned.
+    #
+    expected = {"DS9:" + n for n in names}
+    got = {d.target for d in ds9s}
+    assert expected == got
+
+def test_ds9_get_fits(ds9_obj, test_fits):
     '''get a fits file as an astropy fits object'''
 
     ds9_obj.set('file {}'.format(test_fits))
@@ -152,14 +170,15 @@ def test_ds9_get_fits(monkeypatch, ds9_obj, test_fits):
     assert diff.identical
 
 
-# TODO: change this test so that it passes when an error is raised
-@pytest.mark.xfail(raises=ValueError, reason='Not an astropy hdu')
 def test_ds9_set_fits_fail(ds9_obj):
     '''set_fits wants an astropy HDUList'''
-    ds9_obj.set_fits('random_type')
+
+    with pytest.raises(ValueError,
+                       match='The input must be an astropy HDUList'):
+        ds9_obj.set_fits('random_type')
 
 
-def test_ds9_set_fits(monkeypatch, tmpdir, ds9_obj, test_fits):
+def test_ds9_set_fits(tmpdir, ds9_obj, test_fits):
     '''Set the astropy fits'''
 
     with fits.open(test_fits.strpath) as hdul,\
@@ -195,13 +214,12 @@ def test_get_arr2np(ds9_obj, test_data_dir, fits_name):
     np.testing.assert_array_equal(arr, fits_data)
 
 
-# TODO: change this test so that it passes when an error is raised
-@pytest.mark.xfail(raises=ValueError,
-                   reason='Not a numpy array or not valid shape')
 @parametrize('input_', ['random_type', np.arange(5)])
 def test_ds9_set_np2arr_fail(tmpdir, ds9_obj, input_):
     '''Set the passing wrong arrays'''
-    ds9_obj.set_np2arr(input_)
+
+    with pytest.raises(ValueError):
+        ds9_obj.set_np2arr(input_)
 
 
 @fits_names
@@ -222,17 +240,22 @@ def test_ds9_set_np2arr(tmpdir, ds9_obj, test_data_dir, fits_name):
     np.testing.assert_array_equal(fits_data, fits.getdata(out_fits.strpath))
 
 
-# TODO: split into two tests and check that an error is raised when
-#       expected
-@parametrize('action, args',
-             [(getattr, ()),
-              pytest.param(setattr, (42, ), marks=xfail_attribute_error)
-              ])
 @parametrize('attr', ['target', 'id', 'method'])
-def test_ds9_readonly_props(ds9_obj, action, args, attr):
+def test_ds9_readonly_props(ds9_obj, attr):
     '''Make sure that readonly attributes are such'''
 
-    action(ds9_obj, attr, *args)
+    # we can read them
+    getattr(ds9_obj, attr)
+
+
+@parametrize('attr', ['target', 'id', 'method'])
+def test_ds9_readonly_props_fail(ds9_obj, attr):
+    '''Make sure that readonly attributes are such'''
+
+    # We can not set them
+    with pytest.raises(AttributeError,
+                       match="can't set attribute"):
+        setattr(ds9_obj, attr, 41)
 
 
 def test_ds9_extra_prop(ds9_title):

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -207,7 +207,10 @@ def test_get_arr2np(ds9_obj, test_data_dir, fits_name):
     fits_file = test_data_dir.join(fits_name)
     ds9_obj.set('file {}'.format(fits_file))
 
-    arr = ds9_obj.get_arr2np()
+    with pytest.warns(None) as warn_records:
+        arr = ds9_obj.get_arr2np()
+
+    assert len(warn_records) == 0
 
     fits_data = fits.getdata(fits_file.strpath)
 

--- a/pyds9/tests/test_pyds9.py
+++ b/pyds9/tests/test_pyds9.py
@@ -22,6 +22,9 @@ type_mapping = parametrize('bitpix, dtype ',
                             (-16, np.dtype(np.uint16))
                             ])
 
+# Hopefully DS9 will never support this particular command...
+INVALID_XPA_METHOD = 'made-up-command'
+
 
 @pytest.fixture
 def run_ds9s():
@@ -282,3 +285,18 @@ def test_ds9_extra_prop(ds9_title):
     ds9 = DS9_(target='*' + ds9_title + '*')
     a = ds9.frame
     ds9.frame = int(a) + 1
+
+
+def test_ds9_invalid_xpa_get(ds9_obj):
+    """Ensure we report errors correctly with an invalid command"""
+
+    with pytest.raises(ValueError,
+                       match=r'XPA\$ERROR undefined command for this xpa'):
+        ds9_obj.get(INVALID_XPA_METHOD)
+
+def test_ds9_invalid_xpa_set(ds9_obj):
+    """Ensure we report errors correctly with an invalid command"""
+
+    with pytest.raises(ValueError,
+                       match=r'XPA\$ERROR undefined command for this xpa'):
+        ds9_obj.set(INVALID_XPA_METHOD)

--- a/pyds9/xpa.py
+++ b/pyds9/xpa.py
@@ -112,6 +112,16 @@ def XPAAccess(xpa, target, paramlist, mode, names, messages, n):
 xpa_n = 1024
 
 
+def to_string(buf, size=-1, strip=True):
+    """Wrap conversion of ctypes string to Python"""
+
+    s = ctypes.string_at(buf, size).decode('utf-8')
+    if strip:
+        s = s.strip()
+
+    return s
+
+
 def xpaget(target, plist=None, n=xpa_n):
     buf_t = c_byte_p*n
     bufs = buf_t()
@@ -129,7 +139,7 @@ def xpaget(target, plist=None, n=xpa_n):
                 buf.append(cur)
         for i in range(got):
             if errs[i]:
-                errmsg += ctypes.string_at(errs[i]).strip() + '\n'
+                errmsg += to_string(errs[i]) + '\n'
     else:
         buf = None
     _freebufs(bufs, n)
@@ -153,12 +163,7 @@ def xpaset(target, plist=None, buf=None, blen=-1, n=xpa_n):
     got = XPASet(None, target, plist, None, buf, blen, names, errs, n)
     for i in range(got):
         if errs[i]:
-            as_string = ctypes.string_at(errs[i]).strip()
-            try:
-                as_string = as_string.decode()
-            except AttributeError:  # it's already a string
-                pass
-            errmsg += as_string + '\n'
+            errmsg += to_string(errs[i]) + '\n'
     _freebufs(names, n)
     _freebufs(errs, n)
     if errmsg:
@@ -174,7 +179,7 @@ def xpainfo(target, plist=None, n=xpa_n):
     got = XPAInfo(None, target, plist, None, names, errs, n)
     for i in range(got):
         if errs[i]:
-            errmsg += ctypes.string_at(errs[i]).strip() + '\n'
+            errmsg += to_string(errs[i]) + '\n'
     _freebufs(names, n)
     _freebufs(errs, n)
     if errmsg:
@@ -192,11 +197,10 @@ def xpaaccess(target, plist=None, n=xpa_n):
         buf = []
         for i in range(got):
             if names[i]:
-                cur = ctypes.string_at(names[i]).strip()
-                buf.append(cur)
+                buf.append(to_string(names[i]))
         for i in range(got):
             if errs[i]:
-                errmsg += ctypes.string_at(errs[i]).strip() + '\n'
+                errmsg += to_string(errs[i]) + '\n'
     else:
         buf = None
     _freebufs(names, n)


### PR DESCRIPTION
- [X] clean up test harness

A number of tests were marked as "skip", and its unclear to me why,
so let's run them and see what happens. It wasn't clear what the
actual test should be in one case, so I have tweaked it slightly
(test_ds9_openlist).

Several tests that were marked as "xfail" have been converted to
tests which check that a particular error is raised (with pytest.raises).

- [X] address deprecation warnings shown in tests

```
pyds9/tests/test_pyds9.py::test_get_arr2np[test.fits]
  /tmp/pyds9-test-dttpo3f7/lib/python3.7/site-packages/pyds9/pyds9.py:763: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((h, w))

pyds9/tests/test_pyds9.py::test_get_arr2np[test_3D.fits]
  /tmp/pyds9-test-dttpo3f7/lib/python3.7/site-packages/pyds9/pyds9.py:761: DeprecationWarning: The binary mode of fromstring is deprecated, as it behaves surprisingly on unicode inputs. Use frombuffer instead
    arr = numpy.fromstring(s, dtype=_bp2np(bp)).reshape((d, h, w))
```

- [X] add tests that show current problems with error strings (also see #64)

- [X] fix these tests