### PR TITLE
Update pyds9.py to search for saoimageds9.app

### DIFF
--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -80,13 +80,13 @@ def get_xpans_ds9():
         # look for a "SAOImage DS9.app" directory in ``/Applications``,
         # ``$HOME`` and ``$HOME/Applications``. If it's found use the mac
         # ``open`` command
-        app_names = ["SAOImage DS9.app", "SAOImageDS9.app"]
+        app_names = ["SAOImageDS9.app", "SAOImage DS9.app"]
         user_dir = os.path.expanduser('~')
         for p in ['/Applications', user_dir,
                   os.path.join(user_dir, 'Applications'),
                   os.path.join(user_dir, 'Desktop')]:
             for app_name in app_names:
-            ds9_app_dir = os.path.join(p, app_name):
+                ds9_app_dir = os.path.join(p, app_name):
                 if os.path.exists(ds9_app_dir):
                     ds9 = ['open', '-a', ds9_app_dir, '--args']
                     break

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -80,15 +80,16 @@ def get_xpans_ds9():
         # look for a "SAOImage DS9.app" directory in ``/Applications``,
         # ``$HOME`` and ``$HOME/Applications``. If it's found use the mac
         # ``open`` command
-        ds9_app = "SAOImage DS9.app"
+        app_names = ["SAOImage DS9.app", "SAOImageDS9.app"]
         user_dir = os.path.expanduser('~')
         for p in ['/Applications', user_dir,
                   os.path.join(user_dir, 'Applications'),
                   os.path.join(user_dir, 'Desktop')]:
-            ds9_app_dir = os.path.join(p, ds9_app)
-            if os.path.exists(ds9_app_dir):
-                ds9 = ['open', '-a', ds9_app_dir, '--args']
-                break
+            for app_name in app_names:
+            ds9_app_dir = os.path.join(p, app_name):
+                if os.path.exists(ds9_app_dir):
+                    ds9 = ['open', '-a', ds9_app_dir, '--args']
+                    break
 
         ds9_warning = ("Can't locate the X11 DS9 executable in your PATH or"
                        " the Aqua SAOImage DS9 app in /Applications, $HOME"

--- a/pyds9/pyds9.py
+++ b/pyds9/pyds9.py
@@ -86,7 +86,7 @@ def get_xpans_ds9():
                   os.path.join(user_dir, 'Applications'),
                   os.path.join(user_dir, 'Desktop')]:
             for app_name in app_names:
-                ds9_app_dir = os.path.join(p, app_name):
+                ds9_app_dir = os.path.join(p, app_name)
                 if os.path.exists(ds9_app_dir):
                     ds9 = ['open', '-a', ds9_app_dir, '--args']
                     break


### PR DESCRIPTION
Newer versions of DS9 ship the app as `SAOImageDS9.app` instead of `SAOImage DS9.app`. This change allows finding the first of the two (defaulting to the newer version, so as to default to a newer version of DS9) and using that for the ds9 executable. 